### PR TITLE
Fix rbenv depenencies and config

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,10 +1,12 @@
+default['mailcatcher']['ruby_version'] = '1.9.3-p545'
+
 default['mailcatcher']['http_ip'] = '0.0.0.0'
 default['mailcatcher']['http_port'] = 1080
 
 default['mailcatcher']['smtp_ip'] = '127.0.0.1'
 default['mailcatcher']['smtp_port'] = 1025
 
-default['mailcatcher']['bin'] = 'mailcatcher'
+default['mailcatcher']['bin'] = '/opt/rbenv/shims/mailcatcher'
 default['mailcatcher']['version'] = '0.6.1'
 
-default['mailcatcher']['catchmail_bin'] = 'catchmail'
+default['mailcatcher']['catchmail_bin'] = '/opt/rbenv/shims/catchmail'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,8 +1,15 @@
-# Install MailCatcher service
-include_recipe "rbenv::system_install"
+# Prepare dependencies
+include_recipe 'rbenv::default'
+include_recipe 'rbenv::ruby_build'
+
+rbenv_ruby node['mailcatcher']['ruby_version'] do
+  global true
+end
+
+# Install MailCatcher gem
 
 rbenv_gem 'mailcatcher' do
-  rbenv_version node['rbenv']['global'] if node['rbenv']['global']
+  rbenv_version node['mailcatcher']['ruby_version']
   send('version', node['mailcatcher']['version']) if node['mailcatcher']['version']
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,7 +9,7 @@ end
 # Install MailCatcher gem
 
 rbenv_gem 'mailcatcher' do
-  rbenv_version node['mailcatcher']['ruby_version']
+  ruby_version node['mailcatcher']['ruby_version']
   send('version', node['mailcatcher']['version']) if node['mailcatcher']['version']
 end
 

--- a/templates/default/mailcatcher.init.conf.erb
+++ b/templates/default/mailcatcher.init.conf.erb
@@ -19,6 +19,7 @@ HTTP_PORT="<%= node['mailcatcher']['http_port'] %>"
 SMTP_IP="<%= node['mailcatcher']['smtp_ip'] %>"
 SMTP_PORT="<%= node['mailcatcher']['smtp_port'] %>"
 BIN="<%= node['mailcatcher']['bin'] %>"
+export RBENV_VERSION="<%= node['rbenv']['global'] %>"
 
 start() {
         echo -n "Starting $prog: "
@@ -26,6 +27,7 @@ start() {
         pid=$(pidofproc "$prog")
         echo "$pid" > $PIDFILE
         RETVAL=$?
+        echo ""
         return $RETVAL
 }
 
@@ -33,6 +35,7 @@ stop() {
         echo -n "Shutting down $prog: "
         killproc -p "$PIDFILE" "$BIN"
         RETVAL=$?
+        echo ""
         return $RETVAL
 }
 


### PR DESCRIPTION
- I had to change the usage of `rbenv` recipe in order to get it compling;
- The changes in the init script are to ensure that `rbenv` local never overrides the ruby version when using this script;
- Shims setup as full paths so that any user can run the init script (in particular root user)
- And a small fix to make the init script output well formatted
