### PR TITLE
Update to use supermarket rbenv and not set sytem rbenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Attributes
 | ['mailcatcher']['http_port']        | Integer   | The port of the http server                   | 1080          |
 | ['mailcatcher']['catchmail_bin']    | String    | The location of the CatchMail binary file     | catchmail     |
 | ['mailcatcher']['install_method']   | String    | The install method, rbenv or system           | rbenv         |
-| ['mailcatcher']['ruby_version']     | String    | The rbenv ruby version to use                 | 2.1.7         |
+| ['mailcatcher']['ruby_version']     | String    | The rbenv ruby version to use                 | 2.2.3         |
 | ['mailcatcher']['version']          | String    | The mailcatcher gem version to use            | 0.6.1         |
 | ['mailcatcher']['php_envelope_from']| String    | An optional enveople from email address       | nil           |

--- a/README.md
+++ b/README.md
@@ -13,11 +13,15 @@ Recipes
 Attributes
 ----------
 
-| Key                               | Type      | Description                                   | Default       |
-| --------------------------------- | --------- | --------------------------------------------- | ------------- |
-| ['mailcatcher']['bin']            | String    | The location of the MailCatcher binary file   | mailcatcher   |
-| ['mailcatcher']['smtp_ip']        | String    | The ip address of the smtp server             | 127.0.0.1     |
-| ['mailcatcher']['smtp_port']      | Integer   | The port of the smtp server                   | 1025          |
-| ['mailcatcher']['http_ip']        | String    | The ip address of the http server             | 0.0.0.0       |
-| ['mailcatcher']['http_port']      | Integer   | The port of the http server                   | 1080          |
-| ['mailcatcher']['catchmail_bin']  | String    | The location of the CatchMail binary file     | catchmail     |
+| Key                                 | Type      | Description                                   | Default       |
+| ----------------------------------- | --------- | --------------------------------------------- | ------------- |
+| ['mailcatcher']['bin']              | String    | The location of the MailCatcher binary file   | mailcatcher   |
+| ['mailcatcher']['smtp_ip']          | String    | The ip address of the smtp server             | 127.0.0.1     |
+| ['mailcatcher']['smtp_port']        | Integer   | The port of the smtp server                   | 1025          |
+| ['mailcatcher']['http_ip']          | String    | The ip address of the http server             | 0.0.0.0       |
+| ['mailcatcher']['http_port']        | Integer   | The port of the http server                   | 1080          |
+| ['mailcatcher']['catchmail_bin']    | String    | The location of the CatchMail binary file     | catchmail     |
+| ['mailcatcher']['install_method']   | String    | The install method, rbenv or system           | rbenv         |
+| ['mailcatcher']['ruby_version']     | String    | The rbenv ruby version to use                 | 2.1.7         |
+| ['mailcatcher']['version']          | String    | The mailcatcher gem version to use            | 0.6.1         |
+| ['mailcatcher']['php_envelope_from']| String    | An optional enveople from email address       | nil           |

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,5 +6,9 @@ default['mailcatcher']['smtp_port'] = 1025
 
 default['mailcatcher']['bin'] = 'mailcatcher'
 default['mailcatcher']['version'] = '0.6.1'
+default['mailcatcher']['ruby_version'] = '2.1.7'
 
 default['mailcatcher']['catchmail_bin'] = 'catchmail'
+default['mailcatcher']['install_method'] = 'rbenv'
+
+default['mailcatcher']['php_envelope_from'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@ default['mailcatcher']['smtp_port'] = 1025
 
 default['mailcatcher']['bin'] = 'mailcatcher'
 default['mailcatcher']['version'] = '0.6.1'
-default['mailcatcher']['ruby_version'] = '2.1.7'
+default['mailcatcher']['ruby_version'] = '2.2.3'
 
 default['mailcatcher']['catchmail_bin'] = 'catchmail'
 default['mailcatcher']['install_method'] = 'rbenv'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,9 +1,20 @@
 # Install MailCatcher service
-include_recipe "rbenv::system_install"
+package 'sqlite-devel'
 
-rbenv_gem 'mailcatcher' do
-  rbenv_version node['rbenv']['global'] if node['rbenv']['global']
-  send('version', node['mailcatcher']['version']) if node['mailcatcher']['version']
+if node['mailcatcher']['install_method'] == 'rbenv'
+  include_recipe 'rbenv'
+  include_recipe 'rbenv::ruby_build'
+
+  rbenv_ruby node['mailcatcher']['ruby_version']
+
+  rbenv_gem 'mailcatcher' do
+    ruby_version node['mailcatcher']['ruby_version']
+    send('version', node['mailcatcher']['version']) if node['mailcatcher']['version']
+  end
+else
+  gem_package 'mailcatcher' do
+    send('version', node['mailcatcher']['version']) if node['mailcatcher']['version']
+  end
 end
 
 # Create init scripts for MailCatcher daemon.

--- a/recipes/php.rb
+++ b/recipes/php.rb
@@ -1,8 +1,8 @@
 # Publish PHP configuration
 template "#{node['php']['ext_conf_dir']}/mailcatcher.ini" do
-    source "php/mailcatcher.ini.erb"
-    owner "root"
-    group "root"
-    mode "0644"
-    action :create
+  source "php/mailcatcher.ini.erb"
+  owner "root"
+  group "root"
+  mode "0644"
+  action :create
 end

--- a/templates/default/mailcatcher.init.conf.erb
+++ b/templates/default/mailcatcher.init.conf.erb
@@ -8,6 +8,10 @@
 
 # Source function library.
 . /etc/init.d/functions
+<% if node['mailcatcher']['install_method'] == 'rbenv' %>
+. /etc/profile.d/rbenv.sh
+export RBENV_VERSION="<%= node['mailcatcher']['ruby_version'] %>"
+<% end %>
 
 RETVAL=0
 prog="mailcatcher"

--- a/templates/default/php/mailcatcher.ini.erb
+++ b/templates/default/php/mailcatcher.ini.erb
@@ -1,1 +1,17 @@
-sendmail_path = <%= node['mailcatcher']['catchmail_bin'] %> -f noreply@mailcatcher.me
+<%
+if node['mailcatcher']['install_method'] == 'rbenv'
+  args = [
+    '/bin/env',
+    "RBENV_VERSION=#{node['mailcatcher']['ruby_version']}",
+    "#{node['rbenv']['root_path']}/shims/#{node['mailcatcher']['catchmail_bin']}"
+  ];
+else
+  args = [node['mailcatcher']['catchmail_bin']]
+end
+
+if node['mailcatcher']['php_envelope_from']
+  args << "-f#{node['mailcatcher']['php_envelope_from']}"
+end
+
+%>
+sendmail_path = '<%=args.join(' ')%>'


### PR DESCRIPTION
The rbenv cookbook linked to appears to be https://supermarket.chef.io/cookbooks/ruby_rbenv rather than https://supermarket.chef.io/cookbooks/rbenv

There's little difference between the two, other than one sets up a version by default, and this cookbook wasn't working correctly with the former for php-fpm (needs explicit path to shim).

Additionally I thought it best to not set up a system ruby version, and push the version to the applicable places (init.d and php ini setting)

Additionally php_envelope_from attribute has been created to extract it from the catchmail option, which was stopping PHP applications from being able to supply their own.
