### PR TITLE
Add a postfix recipe for passing everything from postfix to mailcatcher

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,7 @@ description       "Allows for installation of MailCatcher on CentOS boxes."
 version           "0.0.2"
 
 depends "rbenv"
+depends "postfix"
 
 recommends "php"
 recommends "php-fpm"

--- a/recipes/postfix.rb
+++ b/recipes/postfix.rb
@@ -1,0 +1,5 @@
+
+node.set['postfix']['main']['relayhost'] = "[#{node['mailcatcher']['smtp_ip']}]:#{node['mailcatcher']['smtp_port']}"
+node.set['postfix']['main']['mydestination'] = ''
+
+include_recipe 'postfix'


### PR DESCRIPTION
Gotta catch em all

This sends all mail sent to the local postfix service to mailcatcher, including all mail normally delivered locally.
